### PR TITLE
arvanK/defense-mode-for-robot

### DIFF
--- a/commands/CurrentLimiter.java
+++ b/commands/CurrentLimiter.java
@@ -2,10 +2,13 @@ package frc.team670.mustanglib.commands;
 
 import frc.team670.mustanglib.subsystems.MustangSubsystemBase;
 
+/**
+ * stores the subsytem and speed limit for subsytem in RPM used for DefenseModeCommand
+ */
 public class CurrentLimiter {
     public MustangSubsystemBase subsytem;
     public int limit;
-    public int orginalLimit;
+
     public CurrentLimiter(MustangSubsystemBase subsystem, int limit){
         this.subsytem = subsystem;
         this.limit = limit;

--- a/commands/CurrentLimiter.java
+++ b/commands/CurrentLimiter.java
@@ -1,0 +1,13 @@
+package frc.team670.mustanglib.commands;
+
+import frc.team670.mustanglib.subsystems.MustangSubsystemBase;
+
+public class CurrentLimiter {
+    public MustangSubsystemBase subsytem;
+    public int limit;
+    public int orginalLimit;
+    public CurrentLimiter(MustangSubsystemBase subsystem, int limit){
+        this.subsytem = subsystem;
+        this.limit = limit;
+    }
+}

--- a/commands/DefenseModeCommand.java
+++ b/commands/DefenseModeCommand.java
@@ -13,7 +13,7 @@ import frc.team670.mustanglib.utils.motorcontroller.SparkMAXLite;
 
 public class DefenseModeCommand extends InstantCommand implements MustangCommand  {
     List<CurrentLimiter> limiter;
-    List<SparkMAXLite> list = new ArrayList<SparkMAXLite>();
+    List<SparkMAXLite> motorList = new ArrayList<SparkMAXLite>();
     List<Integer> speed = new ArrayList<Integer>();
     List<MustangSubsystemBase> testsubs = new ArrayList<MustangSubsystemBase>();
     Map<MustangSubsystemBase, HealthState> healthreq;
@@ -27,17 +27,22 @@ public class DefenseModeCommand extends InstantCommand implements MustangCommand
     }
 
     public DefenseModeCommand(List<MustangSubsystemBase> unusedSubsytems, int constLimit){
+        
+        //creates a CurrentLimiter using the paramiters pased to later be used in the config
         for (int i = 0; i < unusedSubsytems.size(); i++){
             limiter.set(i, new CurrentLimiter(unusedSubsytems.get(i), constLimit));
         }
+
         config();
     }
 
     void config(){
         for (int i = 0; i < limiter.size(); i++){
+            // loop through subsytems and creates a list of their motors and a list of speeds for the motors
+            // to be used when command is called
             SparkMAXLite[] motors = limiter.get(i).subsytem.getMotors();
             for (SparkMAXLite sparkMAXLite : motors) {
-                list.add(sparkMAXLite);
+                motorList.add(sparkMAXLite);
                 speed.add(limiter.get(i).limit);
             }
         }
@@ -46,8 +51,8 @@ public class DefenseModeCommand extends InstantCommand implements MustangCommand
     
     @Override
     public void initialize(){
-        for (int i = 0; i < list.size(); i++) {
-            list.get(i).set(speed.get(i));
+        for (int i = 0; i < motorList.size(); i++) {
+            motorList.get(i).set(speed.get(i));
         }
     }
 

--- a/commands/DefenseModeCommand.java
+++ b/commands/DefenseModeCommand.java
@@ -1,0 +1,60 @@
+package frc.team670.mustanglib.commands;
+
+import java.util.List;
+import java.util.Map;
+
+
+import java.util.ArrayList;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.team670.mustanglib.subsystems.MustangSubsystemBase;
+import frc.team670.mustanglib.subsystems.MustangSubsystemBase.HealthState;
+import frc.team670.mustanglib.utils.motorcontroller.SparkMAXLite;
+
+public class DefenseModeCommand extends InstantCommand implements MustangCommand  {
+    List<CurrentLimiter> limiter;
+    List<SparkMAXLite> list = new ArrayList<SparkMAXLite>();
+    List<Integer> speed = new ArrayList<Integer>();
+    List<MustangSubsystemBase> testsubs = new ArrayList<MustangSubsystemBase>();
+    Map<MustangSubsystemBase, HealthState> healthreq;
+    
+
+
+    public DefenseModeCommand(List<CurrentLimiter> limiter){
+        this.limiter = limiter;
+        config();
+        
+    }
+
+    public DefenseModeCommand(List<MustangSubsystemBase> unusedSubsytems, int constLimit){
+        for (int i = 0; i < unusedSubsytems.size(); i++){
+            limiter.set(i, new CurrentLimiter(unusedSubsytems.get(i), constLimit));
+        }
+        config();
+    }
+
+    void config(){
+        for (int i = 0; i < limiter.size(); i++){
+            SparkMAXLite[] motors = limiter.get(i).subsytem.getMotors();
+            for (SparkMAXLite sparkMAXLite : motors) {
+                list.add(sparkMAXLite);
+                speed.add(limiter.get(i).limit);
+            }
+        }
+    }
+
+    
+    @Override
+    public void initialize(){
+        for (int i = 0; i < list.size(); i++) {
+            list.get(i).set(speed.get(i));
+        }
+    }
+
+
+    @Override
+    public Map<MustangSubsystemBase, HealthState> getHealthRequirements() {
+        return healthreq;
+    }
+
+}

--- a/subsystems/MustangSubsystemBase.java
+++ b/subsystems/MustangSubsystemBase.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.team670.mustanglib.commands.MustangCommand;
 import frc.team670.mustanglib.commands.MustangScheduler;
 import frc.team670.mustanglib.utils.MustangNotifications;
+import frc.team670.mustanglib.utils.motorcontroller.SparkMAXLite;
 
 /**
  * Basic framework for a subsystem of the robot with defined levels of system
@@ -93,6 +94,8 @@ public abstract class MustangSubsystemBase extends SubsystemBase {
     public void initDefaultCommand(MustangCommand command) {
         MustangScheduler.getInstance().setDefaultCommand(this, command);
     }
+
+    public abstract SparkMAXLite[] getMotors();
 
     /**
      * Checks the health of this subsystem and attempts to run this subsystem's mustangperiodic if the health is yellow unknown or green


### PR DESCRIPTION
# Description

Added CurrentLimiter Class for defense mode command takes in a limit and a subsytem and sets the speed of that subsytem's motor when the DefenseModeCommand is called see bellow

added GetMotors method to MustangSubsystemBase should return an array of SparkMaxLite motors that the subsytem is using

Added DefenseModeCommand
takes in a List array of CurrentLimiters(or the items required to construct one) and gets the motors from each subsytem and stores in a list when called sets the speed of the motors to the corresponding values from the current limiter

allows for disabling unused subsytems during defense mode

Fixes

Defense Mode  #58 

## Affected Subsystems

- [✅] Shooter
- [✅] Intake
- [✅] Indexer
- [✅] Elevator
      
# Steps to Test

set the command to the B button on the controller and had the intake/shooter run and clicked button to see if they would stop spining then started them back up to verify they still worked when they are needed

# Checklist:

- [✅ ] My changes pass ./gradlew build
- [✅ ] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [✅ ] I have made corresponding changes to the documentation
